### PR TITLE
fixes #83 by removing storage and retrieval prevConfig

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R:
 License: Apache License version 2.0 | file LICENSE
 Imports: shiny, shinyFiles, GGIR, bslib, methods, jsonlite, DT, 
     dplyr, magrittr, shinyjs, sf, readr, tidyr, stringr, callr, palmsplusr,
-    data.table, rlang, purrr, geosphere
+    data.table, rlang, purrr, geosphere, lwgeom
 Remotes: vincentvanhees/palmsplusr
 LazyData: true
 Suggests: testthat, covr, rmarkdown

--- a/R/myApp.R
+++ b/R/myApp.R
@@ -11,7 +11,7 @@
 
 # pkgload::load_all("."); HabitusGUI::myApp(homedir="~/projects/fontys") 
 # HabitusGUI::myApp(homedir="~/projects")
-# pkgload::load_all("."); myApp(homedir="~/projects/fontys")
+# pkgload::load_all("."); myApp(homedir="D:/Dropbox/Work/sharedfolder/DATA/Habitus")
 # roxygen2::roxygenise()
 
 
@@ -285,21 +285,7 @@ overflow-y:scroll; max-height: 300px; background: ghostwhite;}")),
     if (length(values$palmspyoutdir) < 2) selectedPalmspyoutdir = c() else selectedPalmspyoutdir = paste(values$palmspyoutdir$path, collapse = .Platform$file.sep)
     if (length(values$sleepdiaryfile) < 2) selectedSleepdiaryfile = c() else selectedSleepdiaryfile = paste(values$sleepdiaryfile$path, collapse = .Platform$file.sep)
     if (length(values$outputdir) < 2) selectedOutputdir = c() else selectedOutputdir = paste(values$outputdir$path, collapse = .Platform$file.sep)
-    
-    # previous config files
-    prevConfigPALMSpy = prevConfigGGIR = prevConfigPalmsplusr = c()
-    if (exists("values")) {
-      if (!is.null(values$configfilePALMSpy)) {
-        prevConfigPALMSpy = values$configfilePALMSpy
-      }
-      if (!is.null(values$configfileGGIR)) {
-        prevConfigGGIR = values$configfileGGIR
-      }
-      if (!is.null(values$configfilepalmsplusr)) {
-        prevConfigPalmsplusr = values$configfilepalmsplusr
-      }
-    }
-    
+
     observeEvent(input$page_12, {
       values_tmp = lapply(reactiveValuesToList(input), unclass)
       if (exists("values") & length(values) > 10) {
@@ -442,17 +428,18 @@ overflow-y:scroll; max-height: 300px; background: ghostwhite;}")),
       values = values_tmp
       # -----
       configs_ready = TRUE
-      if ("PALMSpy" %in% input$tools & !exists("prevConfigPALMSpy")) {
+      config_from = config_to = NULL
+      if ("PALMSpy" %in% input$tools) {
         if (length(paste0(configfilePALMSpy())) == 0) {
           configs_ready = FALSE
         }
       }
-      if ("GGIR" %in% input$tools & !exists("prevConfigGGIR")) {
+      if ("GGIR" %in% input$tools) {
         if (length(paste0(configfileGGIR())) == 0) {
           configs_ready = FALSE
         }
       }
-      if ("palmsplusr" %in% input$tools & !exists("prevConfigPalmsplusr")) {
+      if ("palmsplusr" %in% input$tools) {
         if (length(paste0(configfilepalmsplusr())) == 0) {
           configs_ready = FALSE
         }
@@ -477,15 +464,19 @@ overflow-y:scroll; max-height: 300px; background: ghostwhite;}")),
           config_from = cleanPath(configfileGGIR())
           config_to = cleanPath(paste0(global$data_out, "/config.csv"))
           if (length(config_from) > 0) {
-            values$configfileGGIR = copyFile(from = config_form, to = config_to)
+            values$configfileGGIR = copyFile(from = config_from, to = config_to)
           } 
           if (length(sleepdiaryfile()) > 0) {
-            diary_from = cleanPath(as.character(parseFilePaths(c(home = homedir), sleepdiaryfile())$datapath))
-            diary_to = cleanPath(paste0(global$data_out, "/sleepdiary.csv"))
-            if (length(config_from) > 0) {
-              sleepdiaryfile_local = copyFile(from = diary_form, to = diary_to)
-            } else  {
-              sleepdiaryfile_local = c()
+            if (sleepdiaryfile() != 0) {
+              diary_from = cleanPath(as.character(parseFilePaths(c(home = homedir), sleepdiaryfile())$datapath))
+              diary_to = cleanPath(paste0(global$data_out, "/sleepdiary.csv"))
+              if (length(config_from) > 0) {
+                sleepdiaryfile_local = copyFile(from = diary_form, to = diary_to)
+              } else  {
+                sleepdiaryfile_local = c()
+              }
+            } else {
+              sleepdiaryfile_local = NULL
             }
             if (!is.null(sleepdiaryfile_local)) {
               values$sleepdiaryfile = paste0(global$data_out, "/sleepdiary.csv")
@@ -501,7 +492,7 @@ overflow-y:scroll; max-height: 300px; background: ghostwhite;}")),
         }
         if ("palmsplusr" %in% input$tools) {
           config_from = cleanPath(configfilepalmsplusr())
-          config_to = cleanPath(paste0(global$data_out, "/config.json"))
+          config_to = cleanPath(paste0(global$data_out, "/config_params.csv"))
           if (length(config_from) > 0) {
             values$configfilepalmsplusr = copyFile(from = config_from, to = config_to)
           }
@@ -787,13 +778,11 @@ overflow-y:scroll; max-height: 300px; background: ghostwhite;}")),
     })
     
     
-    
-    
     # Check and Edit config files ---------------------------------------
-    configfilePALMSpy <- modConfigServer("edit_palmspy_config", tool = reactive("PALMSpy"), homedir = homedir, prevConfig = prevConfigPALMSpy)
-    configfileGGIR <- modConfigServer("edit_ggir_config", tool = reactive("GGIR"), homedir = homedir, prevConfig = prevConfigGGIR)
-    configfilepalmsplusr <- modConfigServer("edit_palmsplusr_config", tool = reactive("palmsplusr"), homedir = homedir, prevConfig = prevConfigPalmsplusr)
-
+    configfilePALMSpy <- modConfigServer("edit_palmspy_config", tool = reactive("PALMSpy"), homedir = homedir)
+    configfileGGIR <- modConfigServer("edit_ggir_config", tool = reactive("GGIR"), homedir = homedir)
+    configfilepalmsplusr <- modConfigServer("edit_palmsplusr_config", tool = reactive("palmsplusr"), homedir = homedir)
+    
     
     #========================================================================
     # Apply GGIR / Counts after button is pressed
@@ -825,7 +814,6 @@ overflow-y:scroll; max-height: 300px; background: ghostwhite;}")),
           } else {
             # this line makes that if user is trying to use a config defined in a previous
             # run, the data path is correctly defined
-            if (length(configfileGGIR()) == 0) configfileGGIR = reactive(prevConfigGGIR)
             config = read.csv(as.character(configfileGGIR()))
             config.Counts = config$value[which(config$argument == "do.neishabouricounts")]
             if (as.logical(config.Counts) == TRUE) {

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,13 @@
 \name{NEWS}
 \title{News for Package \pkg{HabitusGUI}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 0.1.9 (GitHub-only-release date: ??-??-2023)}{
+  \itemize{
+    \item Deprecate saving configfile in Shiny state as currently functionality
+    was not working well (e.g. it did not allow for overwriting previous configfile)
+    and to reduce code complexity #83
+  }
+}
 \section{Changes in version 0.1.8 (GitHub-only-release date: 30-06-2023)}{
   \itemize{
     \item Allowing package user to specify the local conda environment location needed for PALMSpy

--- a/man/modConfigServer.Rd
+++ b/man/modConfigServer.Rd
@@ -4,7 +4,7 @@
 \alias{modConfigServer}
 \title{modConfigServer}
 \usage{
-modConfigServer(id, tool, homedir = getwd(), prevConfig = c())
+modConfigServer(id, tool, homedir = getwd())
 }
 \arguments{
 \item{id}{...}
@@ -12,8 +12,6 @@ modConfigServer(id, tool, homedir = getwd(), prevConfig = c())
 \item{tool}{...}
 
 \item{homedir}{character to specify home directory}
-
-\item{prevConfig}{character to specify path to config file selected in previous run}
 }
 \value{
 No object returned, this is a shiny module


### PR DESCRIPTION
Fixes #83 
New configfile edits where not captured when code uses previous configfile. This PR removes the prevConfig retrieval by which we go back to forcing user to always specify the config file manually, which ensures that there can be no misunderstanding about what config file was used. The configfile is stored, so even if browser closes it will not be lost. Maybe in the future we can streamline this and still do some kind of configfile memorisation, but for now this address the issue and it helps to reduce code complexity.

<!-- Describe your PR here -->

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [x] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [x] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` and `CITATION.cff` files.
